### PR TITLE
Add babelified esm bundle

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,11 @@
+{
+	"env": {
+		"esm": {
+			"presets": [
+		    ["es2015", {
+		      "modules": false
+		    }]
+		  ]
+		}
+	}
+}

--- a/esm.js
+++ b/esm.js
@@ -1,0 +1,97 @@
+/*! (c) 2017 Andrea Giammarchi @WebReflection, (ISC) */
+
+export var Map = window.Map || function Map() {
+  var i = void 0,
+      k = void 0,
+      v = void 0;
+  var clear = function clear() {
+    k = [];v = [];
+  };
+  var has = function has(obj) {
+    return -1 < (i = k.indexOf(obj));
+  };
+  return clear(), {
+    get size() {
+      return k.length;
+    },
+    has: has,
+    clear: clear,
+    get: function get(obj) {
+      return v[k.indexOf(obj)];
+    },
+    keys: function keys() {
+      return k.slice();
+    },
+    values: function values() {
+      return v.slice();
+    },
+    entries: function entries() {
+      return k.map(function (key, i) {
+        return [key, v[i]];
+      });
+    },
+    delete: function _delete(obj) {
+      return has(obj) && k.splice(i, 1) && !!v.splice(i, 1);
+    },
+    forEach: function forEach(fn, self) {
+      var _this = this;
+
+      v.forEach(function (value, i) {
+        return fn.call(self, value, k[i], _this);
+      });
+    },
+    set: function set(obj, value) {
+      return has(obj) ? v[i] = value : v[k.push(obj) - 1] = value, this;
+    }
+  };
+};
+
+export var Set = window.Set || function Set() {
+  var m = new Map();
+  var set = m.set;
+  delete m.get;
+  delete m.set;
+  m.add = function (obj) {
+    return set.call(m, obj, obj);
+  };
+  return m;
+};
+
+var i = 0;
+var hOP = {}.hasOwnProperty;
+export var WeakMap = window.WeakMap || function WeakMap() {
+  var id = '__' + [i++, Math.random()];
+  var has = function has(obj) {
+    return hOP.call(obj, id);
+  };
+  return {
+    has: has,
+    get: function get(obj) {
+      return obj[id];
+    },
+    delete: function _delete(obj) {
+      return has(obj) && delete obj[id];
+    },
+    set: function set(obj, value) {
+      Object.defineProperty(obj, id, {
+        configurable: true,
+        value: value
+      });
+      return this;
+    }
+  };
+};
+
+export var WeakSet = window.WeakSet || function WeakSet() {
+  var wm = new WeakMap();
+  return {
+    has: function has(obj) {
+      return wm.get(obj) === true;
+    },
+    delete: wm.delete,
+    add: function add(obj) {
+      wm.set(obj, true);
+      return this;
+    }
+  };
+};

--- a/package.json
+++ b/package.json
@@ -3,16 +3,18 @@
   "version": "0.1.2",
   "description": "coming soon",
   "unpkg": "min.js",
+  "module": "esm.js",
   "main": "index.js",
   "scripts": {
     "coveralls": "cat ./coverage/lcov.info | coveralls",
-    "build": "npm run test && npm run _es5 && npm run _fixb && npm run _minify && npm run _clean && npm run size",
+    "build": "npm run test && npm run _esm && npm run _es5 && npm run _fixb && npm run _minify && npm run _clean && npm run size",
     "size": "cat index.js | wc -c;cat min.js | wc -c;gzip -c min.js | wc -c",
     "test": "node test/c.js && istanbul cover test/test.c.js",
     "_clean": "rm test/test.c.js && rm index.{b,c}.js",
     "_es5": "babel ./index.c.js --out-file ./index.b.js --presets=es2015",
-    "_fixb": "sed -i 's/(undefined)/(this)/' ./index.b.js",
-    "_minify": "uglifyjs ./index.b.js --comments=/^!/ --compress --mangle -o min.js"
+    "_fixb": "sed -i '' 's/(undefined)/(this)/' ./index.b.js",
+    "_minify": "uglifyjs ./index.b.js --comments=/^!/ --compress --mangle -o min.js",
+    "_esm": "BABEL_ENV=esm babel ./index.js --out-file ./esm.js"
   },
   "author": "Andrea Giammarchi",
   "license": "ISC",


### PR DESCRIPTION
### Expected Behavior

When importing `poorlyfills` with `import`/`export` aware tooling (rollup in my case), I expect ES5 code to be imported without needing to pass it through babel.

### Actual Behavior

`main` is set to `index.js` which contains ES6 language features such as `const` and `=>`.

The documentation for `jsnext:main` and `pkg.module` recommends providing a code bundle that works in all environments the library aims to support.

https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features

It's a little subjective of course but generally when I import a package from node_modules I shouldn't have to worry about running it through Babel. I know the rollup babel plugin has a recommended configuration of `babel({ exclude: 'node_modules/**' })` which makes a lot of sense IMO. 

### Solution

This change adds a `pkg.module` which uses ESM modules but has ES5 code in it.